### PR TITLE
Added build scripts and versioning information for new plugin system

### DIFF
--- a/UECIDE-Core/hardware/boards/Tiny/build.xml
+++ b/UECIDE-Core/hardware/boards/Tiny/build.xml
@@ -1,0 +1,58 @@
+<project name="boards" default="build">
+
+    <taskdef resource="net/sf/antcontrib/antcontrib.properties">
+        <classpath>
+            <pathelement location="/usr/share/java/ant-contrib-1.0b5-SNAPSHOT.jar"/>
+        </classpath>
+    </taskdef>
+
+    <target name="build">
+        <foreach target="build-board" param="dir" inheritall="true">
+            <path>
+                <dirset dir=".">
+                    <include name="*" />
+                </dirset>
+            </path>
+        </foreach>
+    </target>
+    
+    <target name="install" depends="build">
+        <foreach target="install-board" param="filepath" inheritall="true">
+            <path>
+                <fileset dir=".">
+                    <include name="*.jar" />
+                </fileset>
+            </path>
+        </foreach>
+    </target>
+    
+    <target name="build-board">
+        <basename file="${dir}" property="subdir"/>
+        <property file="${subdir}/board.txt"/>
+        <propertyregex property="prefix"
+                       input="${group}"
+                       defaultValue="${group}"
+                       regexp=" "
+                       replace="_"
+                       global="true"/>
+
+        <jar destfile="${prefix}-${subdir}.jar">
+            <zipfileset dir="${subdir}" prefix="${group}/${subdir}"/>
+            <manifest>
+                <attribute name="Group" value="${group}" />
+                <attribute name="Board" value="${subdir}" />
+                <attribute name="Version" value="${version}-${revision}" />
+                <attribute name="Author" value="${group}" />
+                <attribute name="Platform" value="any" />
+                <attribute name="Description" value="${name}" />
+                <attribute name="Family" value="${family}" />
+            </manifest>
+        </jar>
+    </target>
+
+    <target name="install-board">
+        <basename file="${filepath}" property="file"/>
+        <move file="${file}" todir="/var/www/uecide/plugins/boards/" />
+    </target>
+
+</project>

--- a/UECIDE-Core/hardware/boards/build.xml
+++ b/UECIDE-Core/hardware/boards/build.xml
@@ -1,0 +1,19 @@
+<project name="boards" default="build">
+
+    <taskdef resource="net/sf/antcontrib/antcontrib.properties">
+        <classpath>
+            <pathelement location="/usr/share/java/ant-contrib-1.0b5-SNAPSHOT.jar"/>
+        </classpath>
+    </taskdef>
+
+    <target name="build">
+        <subant target="build">
+            <dirset dir="." includes="*"/>
+        </subant>
+    </target>
+    <target name="install">
+        <subant target="install">
+            <dirset dir="." includes="*"/>
+        </subant>
+    </target>
+</project>

--- a/UECIDE-Core/hardware/cores/build.xml
+++ b/UECIDE-Core/hardware/cores/build.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<project name="avrtiny" default="build">
+
+    <property name="version" value="100" />
+    <property name="revision" value="1001" />
+
+    <target name="build">
+
+        <jar basedir="." destfile="tiny.jar" includes="tiny/**/*">
+            <manifest>
+                <attribute name="Version" value="${version}-${revision}" />
+                <attribute name="Author" value="TCWORLD" />
+                <attribute name="Compiler" value="avr-gcc" />
+                <attribute name="Core" value="tiny" />
+                <attribute name="Platform" value="any" />
+                <attribute name="Family" value="avrtiny" />
+                <attribute name="Description" value="A Beta ATTiny Core" />
+            </manifest>
+        </jar>
+
+        <jar basedir="." destfile="tinyNoMillis.jar" includes="tinyNoMillis/**/*">
+            <manifest>
+                <attribute name="Version" value="${version}-${revision}" />
+                <attribute name="Author" value="TCWORLD" />
+                <attribute name="Compiler" value="avr-gcc" />
+                <attribute name="Core" value="tinyNoMillis" />
+                <attribute name="Platform" value="any" />
+                <attribute name="Family" value="avrtiny" />
+                <attribute name="Description" value="A Beta ATTiny Core" />
+            </manifest>
+        </jar>
+    </target>
+
+    <target name="install" depends="build">
+        <move file="tiny.jar" todir="/var/www/uecide/plugins/cores" />
+        <move file="tinyNoMillis.jar" todir="/var/www/uecide/plugins/cores" />
+    </target>
+
+    <target name="clean">
+        <delete file="tiny.jar" />
+        <delete file="tinyNoMillis.jar" />
+    </target>
+
+
+</project>

--- a/UECIDE-Core/hardware/cores/tiny/core.txt
+++ b/UECIDE-Core/hardware/cores/tiny/core.txt
@@ -7,6 +7,8 @@ core.flags=-DF_CPU=${build.f_cpu}::-DARDUINO=${core.version}::-D${board}
 core.header=Arduino.h
 core.version=100
 core.revision=1001
+version=100
+revision=1001
 
 family=avrtiny
 

--- a/UECIDE-Core/hardware/cores/tinyNoMillis/core.txt
+++ b/UECIDE-Core/hardware/cores/tinyNoMillis/core.txt
@@ -7,6 +7,8 @@ core.flags=-DF_CPU=${build.f_cpu}::-DARDUINO=${core.version}::-D${board}
 core.header=Arduino.h
 core.version=100
 core.revision=1000
+version=100
+revision=1000
 
 family=avrtiny
 


### PR DESCRIPTION
I am in the process of upgrading the whole UECIDE plugin system, and it requires a couple of minor changes to the core.txt files.  I have also added some ant build.xml scripts to deal with packaging the objects up for insertion into the distribution site.
