### PR TITLE
Updated for new plugins path

### DIFF
--- a/UECIDE-Core/hardware/boards/Tiny/build.xml
+++ b/UECIDE-Core/hardware/boards/Tiny/build.xml
@@ -53,7 +53,7 @@
 
     <target name="install-board">
         <basename file="${filepath}" property="file"/>
-        <move file="${file}" todir="/var/www/uecide/plugins/boards/" />
+        <move file="${file}" todir="/var/www/uecide/plugins-087/boards/" />
     </target>
 
 </project>

--- a/UECIDE-Core/hardware/cores/build.xml
+++ b/UECIDE-Core/hardware/cores/build.xml
@@ -32,8 +32,8 @@
     </target>
 
     <target name="install" depends="build">
-        <move file="tiny.jar" todir="/var/www/uecide/plugins/cores" />
-        <move file="tinyNoMillis.jar" todir="/var/www/uecide/plugins/cores" />
+        <move file="tiny.jar" todir="/var/www/uecide/plugins-087/cores" />
+        <move file="tinyNoMillis.jar" todir="/var/www/uecide/plugins-087/cores" />
     </target>
 
     <target name="clean">


### PR DESCRIPTION
The plugins for the new version are stored in a different location. This updates the install path to reflect that change.
